### PR TITLE
feat: optuna keras example

### DIFF
--- a/optuna/keras/keras_simple.py
+++ b/optuna/keras/keras_simple.py
@@ -1,0 +1,106 @@
+"""
+Optuna example that optimizes a neural network classifier configuration for the
+MNIST dataset using Keras.
+
+In this example, we optimize the validation accuracy of MNIST classification using
+Keras. We optimize the filter and kernel size, kernel stride and layer activation.
+
+"""
+import urllib
+import warnings
+
+import optuna
+
+from keras.backend import clear_session
+from keras.datasets import mnist
+from keras.layers import Conv2D
+from keras.layers import Dense
+from keras.layers import Flatten
+from keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
+
+
+# TODO(crcrpar): Remove the below three lines once everything is ok.
+# Register a global custom opener to avoid HTTP Error 403: Forbidden when downloading MNIST.
+opener = urllib.request.build_opener()
+opener.addheaders = [("User-agent", "Mozilla/5.0")]
+urllib.request.install_opener(opener)
+
+
+N_TRAIN_EXAMPLES = 3000
+N_VALID_EXAMPLES = 1000
+BATCHSIZE = 128
+CLASSES = 10
+EPOCHS = 10
+
+
+def objective(trial):
+    # Clear clutter from previous Keras session graphs.
+    clear_session()
+
+    (x_train, y_train), (x_valid, y_valid) = mnist.load_data()
+    img_x, img_y = x_train.shape[1], x_train.shape[2]
+    x_train = x_train.reshape(-1, img_x, img_y, 1)[:N_TRAIN_EXAMPLES].astype("float32") / 255
+    x_valid = x_valid.reshape(-1, img_x, img_y, 1)[:N_VALID_EXAMPLES].astype("float32") / 255
+    y_train = y_train[:N_TRAIN_EXAMPLES]
+    y_valid = y_valid[:N_VALID_EXAMPLES]
+    input_shape = (img_x, img_y, 1)
+
+    model = Sequential()
+    model.add(
+        Conv2D(
+            filters=trial.suggest_categorical("filters", [32, 64]),
+            kernel_size=trial.suggest_categorical("kernel_size", [3, 5]),
+            strides=trial.suggest_categorical("strides", [1, 2]),
+            activation=trial.suggest_categorical("activation", ["relu", "linear"]),
+            input_shape=input_shape,
+        )
+    )
+    model.add(Flatten())
+    model.add(Dense(CLASSES, activation="softmax"))
+
+    # We compile our model with a sampled learning rate.
+    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True)
+    model.compile(
+        loss="sparse_categorical_crossentropy",
+        optimizer=RMSprop(learning_rate=learning_rate),
+        metrics=["accuracy"],
+    )
+
+    model.fit(
+        x_train,
+        y_train,
+        validation_data=(x_valid, y_valid),
+        shuffle=True,
+        batch_size=BATCHSIZE,
+        epochs=EPOCHS,
+        verbose=False,
+    )
+
+    # Evaluate the model accuracy on the validation set.
+    score = model.evaluate(x_valid, y_valid, verbose=0)
+    return score[1]
+
+
+if __name__ == "__main__":
+    warnings.warn(
+        "Recent Keras release (2.4.0) simply redirects all APIs "
+        "in the standalone keras package to point to tf.keras. "
+        "There is now only one Keras: tf.keras. "
+        "There may be some breaking changes for some workflows by upgrading to keras 2.4.0. "
+        "Test before upgrading. "
+        "REF:https://github.com/keras-team/keras/releases/tag/2.4.0"
+    )
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=100, timeout=600)
+
+    print("Number of finished trials: {}".format(len(study.trials)))
+
+    print("Best trial:")
+    trial = study.best_trial
+
+    print("  Value: {}".format(trial.value))
+
+    print("  Params: ")
+    for key, value in trial.params.items():
+        print("    {}: {}".format(key, value))

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-pandas
-matplotlib
-scikit-learn
+keras
+optuna
+tensorflow
+tensorflow-datasets


### PR DESCRIPTION
[optuna](https://github.com/optuna/optuna)에서 제공하는 [keras example](https://github.com/optuna/optuna-examples/blob/main/keras/keras_simple.py)을 실행하여
예시 Best trial Value를 도출하였습니다.

`keras_simple.py` 파일을 변형하여
필요한 데이터를 넣고 `hyperparameter`를 자동으로 찾을 수 있습니다.

python 가상환경을 구축 한 뒤
```shell
pip install -r requirements.txt
```
을 실행하여 환경을 구축하였습니다.

[vsc python 가상환경 구축하는 방법](https://studying-haeung.tistory.com/18)

아래는 실행 결과입니다.

<details>
<summary>눌러서 결과 보기</summary>

<!-- summary 아래 한칸 공백 두어야함 -->

```
E:\github\daegu-traffic-accident-prediction\venv\Scripts\python.exe E:\github\daegu-traffic-accident-prediction\optuna\keras\keras_simple.py 
2023-12-08 20:42:54.331280: I tensorflow/core/util/port.cc:113] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
WARNING:tensorflow:From E:\github\daegu-traffic-accident-prediction\venv\Lib\site-packages\keras\src\losses.py:2976: The name tf.losses.sparse_softmax_cross_entropy is deprecated. Please use tf.compat.v1.losses.sparse_softmax_cross_entropy instead.

E:\github\daegu-traffic-accident-prediction\optuna\keras\keras_simple.py:86: UserWarning: Recent Keras release (2.4.0) simply redirects all APIs in the standalone keras package to point to tf.keras. There is now only one Keras: tf.keras. There may be some breaking changes for some workflows by upgrading to keras 2.4.0. Test before upgrading. REF:https://github.com/keras-team/keras/releases/tag/2.4.0
  warnings.warn(
[I 2023-12-08 20:42:58,814] A new study created in memory with name: no-name-8200441f-c4cc-41cc-bf3e-a290f43c562e
WARNING:tensorflow:From E:\github\daegu-traffic-accident-prediction\venv\Lib\site-packages\keras\src\backend.py:277: The name tf.reset_default_graph is deprecated. Please use tf.compat.v1.reset_default_graph instead.

Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz
11490434/11490434 [==============================] - 1s 0us/step
2023-12-08 20:43:00.567977: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: SSE SSE2 SSE3 SSE4.1 SSE4.2 AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
WARNING:tensorflow:From E:\github\daegu-traffic-accident-prediction\venv\Lib\site-packages\keras\src\utils\tf_utils.py:492: The name tf.ragged.RaggedTensorValue is deprecated. Please use tf.compat.v1.ragged.RaggedTensorValue instead.

WARNING:tensorflow:From E:\github\daegu-traffic-accident-prediction\venv\Lib\site-packages\keras\src\engine\base_layer_utils.py:384: The name tf.executing_eagerly_outside_functions is deprecated. Please use tf.compat.v1.executing_eagerly_outside_functions instead.

[I 2023-12-08 20:43:02,630] Trial 0 finished with value: 0.8640000224113464 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 2, 'activation': 'linear', 'learning_rate': 0.000207032523354075}. Best is trial 0 with value: 0.8640000224113464.
[I 2023-12-08 20:43:04,746] Trial 1 finished with value: 0.8349999785423279 and parameters: {'filters': 32, 'kernel_size': 3, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.07203542496477458}. Best is trial 0 with value: 0.8640000224113464.
[I 2023-12-08 20:43:06,689] Trial 2 finished with value: 0.9179999828338623 and parameters: {'filters': 32, 'kernel_size': 3, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.012420442645275486}. Best is trial 2 with value: 0.9179999828338623.
[I 2023-12-08 20:43:09,427] Trial 3 finished with value: 0.8479999899864197 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 6.0234090397259136e-05}. Best is trial 2 with value: 0.9179999828338623.
[I 2023-12-08 20:43:11,645] Trial 4 finished with value: 0.8410000205039978 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 2, 'activation': 'linear', 'learning_rate': 0.06349420047654833}. Best is trial 2 with value: 0.9179999828338623.
[I 2023-12-08 20:43:16,585] Trial 5 finished with value: 0.9179999828338623 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.037449790708641045}. Best is trial 2 with value: 0.9179999828338623.
[I 2023-12-08 20:43:19,786] Trial 6 finished with value: 0.9290000200271606 and parameters: {'filters': 32, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.028276681739475527}. Best is trial 6 with value: 0.9290000200271606.
[I 2023-12-08 20:43:22,398] Trial 7 finished with value: 0.9300000071525574 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.009970825378283468}. Best is trial 7 with value: 0.9300000071525574.
[I 2023-12-08 20:43:25,429] Trial 8 finished with value: 0.8420000076293945 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.026203140532740848}. Best is trial 7 with value: 0.9300000071525574.
[I 2023-12-08 20:43:27,688] Trial 9 finished with value: 0.8889999985694885 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.0005894520042960749}. Best is trial 7 with value: 0.9300000071525574.
[I 2023-12-08 20:43:29,940] Trial 10 finished with value: 0.8460000157356262 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 2, 'activation': 'linear', 'learning_rate': 0.003604431424681713}. Best is trial 7 with value: 0.9300000071525574.
[I 2023-12-08 20:43:34,850] Trial 11 finished with value: 0.9369999766349792 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004239001932865846}. Best is trial 11 with value: 0.9369999766349792.
[I 2023-12-08 20:43:40,090] Trial 12 finished with value: 0.9319999814033508 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0039756099177617075}. Best is trial 11 with value: 0.9369999766349792.
[I 2023-12-08 20:43:46,430] Trial 13 finished with value: 0.9020000100135803 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0014666616285458835}. Best is trial 11 with value: 0.9369999766349792.
[I 2023-12-08 20:43:51,719] Trial 14 finished with value: 0.925000011920929 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0029983794558660157}. Best is trial 11 with value: 0.9369999766349792.
[I 2023-12-08 20:43:57,371] Trial 15 finished with value: 0.8920000195503235 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0006361633508055541}. Best is trial 11 with value: 0.9369999766349792.
[I 2023-12-08 20:44:02,808] Trial 16 finished with value: 0.9390000104904175 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.007045316032042003}. Best is trial 16 with value: 0.9390000104904175.
[I 2023-12-08 20:44:08,041] Trial 17 finished with value: 0.7519999742507935 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 1.889960917822828e-05}. Best is trial 16 with value: 0.9390000104904175.
[I 2023-12-08 20:44:12,727] Trial 18 finished with value: 0.6470000147819519 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.009012777289100727}. Best is trial 16 with value: 0.9390000104904175.
[I 2023-12-08 20:44:18,705] Trial 19 finished with value: 0.9300000071525574 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0016263162864066385}. Best is trial 16 with value: 0.9390000104904175.
[I 2023-12-08 20:44:23,941] Trial 20 finished with value: 0.9399999976158142 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.006633921947540223}. Best is trial 20 with value: 0.9399999976158142.
[I 2023-12-08 20:44:29,035] Trial 21 finished with value: 0.9440000057220459 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.006427345961909027}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:34,149] Trial 22 finished with value: 0.9419999718666077 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.01150332535021496}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:39,302] Trial 23 finished with value: 0.9369999766349792 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.015317079867321587}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:44,384] Trial 24 finished with value: 0.8820000290870667 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.09490981741366243}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:49,312] Trial 25 finished with value: 0.9340000152587891 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.019769728389731497}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:53,614] Trial 26 finished with value: 0.8009999990463257 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.007481112791824165}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:44:58,765] Trial 27 finished with value: 0.9100000262260437 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.03458632426312195}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:03,973] Trial 28 finished with value: 0.9340000152587891 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.015149303972218874}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:06,861] Trial 29 finished with value: 0.8460000157356262 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.001676009623550166}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:11,907] Trial 30 finished with value: 0.9359999895095825 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.005854293967435935}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:17,018] Trial 31 finished with value: 0.9390000104904175 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.006707740846889565}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:21,989] Trial 32 finished with value: 0.9369999766349792 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.012058340761846606}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:27,437] Trial 33 finished with value: 0.9290000200271606 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0025327793241392937}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:29,522] Trial 34 finished with value: 0.9319999814033508 and parameters: {'filters': 32, 'kernel_size': 3, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.005952748963115252}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:35,086] Trial 35 finished with value: 0.9369999766349792 and parameters: {'filters': 64, 'kernel_size': 3, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.016215278290537656}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:37,116] Trial 36 finished with value: 0.8059999942779541 and parameters: {'filters': 32, 'kernel_size': 3, 'strides': 2, 'activation': 'linear', 'learning_rate': 0.06777708445973392}. Best is trial 21 with value: 0.9440000057220459.
[I 2023-12-08 20:45:42,138] Trial 37 finished with value: 0.953000009059906 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.010994825299356206}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:45:47,090] Trial 38 finished with value: 0.9409999847412109 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.03454866823774824}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:45:49,061] Trial 39 finished with value: 0.8999999761581421 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.03610504975849074}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:45:53,636] Trial 40 finished with value: 0.8569999933242798 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.05740624381334561}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:45:58,730] Trial 41 finished with value: 0.9419999718666077 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.024033087036885385}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:46:03,648] Trial 42 finished with value: 0.9470000267028809 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.02113593698935553}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:46:08,658] Trial 43 finished with value: 0.9259999990463257 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.024681107119102916}. Best is trial 37 with value: 0.953000009059906.
[I 2023-12-08 20:46:14,307] Trial 44 finished with value: 0.9549999833106995 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.01128391426724001}. Best is trial 44 with value: 0.9549999833106995.
[I 2023-12-08 20:46:19,309] Trial 45 finished with value: 0.9570000171661377 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.011230366757771655}. Best is trial 45 with value: 0.9570000171661377.
[I 2023-12-08 20:46:21,606] Trial 46 finished with value: 0.9010000228881836 and parameters: {'filters': 64, 'kernel_size': 5, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.05092042330281326}. Best is trial 45 with value: 0.9570000171661377.
[I 2023-12-08 20:46:24,494] Trial 47 finished with value: 0.9580000042915344 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.011535494386259929}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:27,572] Trial 48 finished with value: 0.9570000171661377 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.011639386280792991}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:30,583] Trial 49 finished with value: 0.9319999814033508 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.011244073941365704}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:33,485] Trial 50 finished with value: 0.9549999833106995 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004175019740394391}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:36,606] Trial 51 finished with value: 0.949999988079071 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004217837708095544}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:39,629] Trial 52 finished with value: 0.953000009059906 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.009921054645487369}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:42,748] Trial 53 finished with value: 0.9449999928474426 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.015990679996442807}. Best is trial 47 with value: 0.9580000042915344.
[I 2023-12-08 20:46:45,613] Trial 54 finished with value: 0.9589999914169312 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004621619830797159}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:46:48,582] Trial 55 finished with value: 0.9509999752044678 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.00466638427017141}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:46:51,767] Trial 56 finished with value: 0.949999988079071 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0023884257364272386}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:46:53,788] Trial 57 finished with value: 0.8539999723434448 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 2, 'activation': 'linear', 'learning_rate': 0.0030277170910651477}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:46:56,865] Trial 58 finished with value: 0.953000009059906 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.00869660136547979}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:46:59,904] Trial 59 finished with value: 0.9509999752044678 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.005119025736992588}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:47:03,452] Trial 60 finished with value: 0.9549999833106995 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.003706044953451079}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:47:06,637] Trial 61 finished with value: 0.9570000171661377 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0036013740069156825}. Best is trial 54 with value: 0.9589999914169312.
[I 2023-12-08 20:47:09,580] Trial 62 finished with value: 0.9599999785423279 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0074984834925075705}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:13,104] Trial 63 finished with value: 0.9539999961853027 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.008034813609478938}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:16,116] Trial 64 finished with value: 0.9449999928474426 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.014531084117762735}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:19,358] Trial 65 finished with value: 0.9589999914169312 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.00895725416926824}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:22,475] Trial 66 finished with value: 0.9539999961853027 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.008137642090094498}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:25,452] Trial 67 finished with value: 0.9520000219345093 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0055186405286155454}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:28,232] Trial 68 finished with value: 0.8700000047683716 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.020117024116913036}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:31,057] Trial 69 finished with value: 0.9490000009536743 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0031919888467627274}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:33,907] Trial 70 finished with value: 0.9369999766349792 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0019711557814585767}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:36,741] Trial 71 finished with value: 0.9549999833106995 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.009863532825434928}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:39,772] Trial 72 finished with value: 0.9520000219345093 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.013255800708732906}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:42,972] Trial 73 finished with value: 0.9589999914169312 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.006595187384250217}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:46,111] Trial 74 finished with value: 0.9480000138282776 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.007485787084663585}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:49,090] Trial 75 finished with value: 0.9589999914169312 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0051878575963604226}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:51,364] Trial 76 finished with value: 0.9350000023841858 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.006138299844147119}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:54,353] Trial 77 finished with value: 0.9449999928474426 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.017207582515583908}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:47:57,319] Trial 78 finished with value: 0.9459999799728394 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0049874061462681285}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:00,227] Trial 79 finished with value: 0.9300000071525574 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.013101106461538658}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:02,881] Trial 80 finished with value: 0.800000011920929 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.028044539263696783}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:05,731] Trial 81 finished with value: 0.9559999704360962 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0035462445274090574}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:08,819] Trial 82 finished with value: 0.9549999833106995 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.007164199645948348}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:11,692] Trial 83 finished with value: 0.9539999961853027 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.009159858937106524}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:14,611] Trial 84 finished with value: 0.9440000057220459 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0011973447339304899}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:17,949] Trial 85 finished with value: 0.9599999785423279 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004849602910093257}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:21,247] Trial 86 finished with value: 0.9570000171661377 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.005186190510205672}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:24,172] Trial 87 finished with value: 0.953000009059906 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.006428769423977608}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:26,125] Trial 88 finished with value: 0.9210000038146973 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 2, 'activation': 'relu', 'learning_rate': 0.012559602201590322}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:28,948] Trial 89 finished with value: 0.9509999752044678 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.002503562577413286}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:31,836] Trial 90 finished with value: 0.9369999766349792 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.018970592077486713}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:34,725] Trial 91 finished with value: 0.949999988079071 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004228566484910658}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:37,974] Trial 92 finished with value: 0.9490000009536743 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.008953430822964849}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:41,094] Trial 93 finished with value: 0.9570000171661377 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.005964789814056228}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:44,050] Trial 94 finished with value: 0.9430000185966492 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.010218396166403779}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:47,036] Trial 95 finished with value: 0.9589999914169312 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.0035134008817969873}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:50,002] Trial 96 finished with value: 0.9279999732971191 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.004778159890290583}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:53,067] Trial 97 finished with value: 0.9549999833106995 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.00734431929633047}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:55,860] Trial 98 finished with value: 0.8429999947547913 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'linear', 'learning_rate': 0.0031658132849939117}. Best is trial 62 with value: 0.9599999785423279.
[I 2023-12-08 20:48:59,131] Trial 99 finished with value: 0.9470000267028809 and parameters: {'filters': 32, 'kernel_size': 5, 'strides': 1, 'activation': 'relu', 'learning_rate': 0.015013232330008255}. Best is trial 62 with value: 0.9599999785423279.
Number of finished trials: 100
Best trial:
  Value: 0.9599999785423279
  Params: 
    filters: 32
    kernel_size: 5
    strides: 1
    activation: relu
    learning_rate: 0.0074984834925075705

Process finished with exit code 0

```

</details>
